### PR TITLE
Assignment 5 - change tempfile to mktemp

### DIFF
--- a/test/assignment5/sockettest.sh
+++ b/test/assignment5/sockettest.sh
@@ -45,8 +45,8 @@ function test_send_socket_string
 {
 	string=$1
 	prev_file=$2
-	new_file=`tempfile`
-	expected_file=`tempfile`
+	new_file=$(mktemp)
+	expected_file=$(mktemp)
 
 	echo "sending string ${string} to ${target} on port ${port}"
 	echo ${string} | nc ${target} ${port} -w 1 > ${new_file}
@@ -71,7 +71,7 @@ function test_send_socket_string
 	fi
 }
 
-comparefile=`tempfile`
+comparefile=$(mktemp)
 test_send_socket_string "abcdefg" ${comparefile}
 test_send_socket_string "hijklmnop" ${comparefile}
 test_send_socket_string "1234567890" ${comparefile}


### PR DESCRIPTION
Request to change tempfile to mktemp because tempfile is technically [deprecated](https://www.unix.com/man-page/linux/1/tempfile/): 

> tempfile is deprecated; you should use [mktemp(1)](https://www.unix.com/man-page/linux/1/mktemp/) instead.

The tempfile command still works on Ubuntu 20.04.3, but the `sockettest.sh` script fails for me on Arch due to tempfile command. I tested the mktemp version on Ubuntu 20.04.3 and `sockettest.sh` passes. 