### PR TITLE
Fix error print for string 2

### DIFF
--- a/test/assignment6/sockettest.sh
+++ b/test/assignment6/sockettest.sh
@@ -202,7 +202,7 @@ function validate_multithreaded
 			echo "But expected ${process_send_count} instances"
 		fi
 
-		if [ ${count_thread1} -ne ${process_send_count} ]; then
+		if [ ${count_thread2} -ne ${process_send_count} ]; then
 			echo "Found $count_thread2 instance of string -> $string2 in ${new_file} "
 			echo "But expected ${process_send_count} instances"
 		fi


### PR DESCRIPTION
Assignment 6 error prints didn't reference the correct string
in the check, meaning no error strings were printed in mismatch
cases.