### PR TITLE
Update assignment-test.sh, grep message corrected

### DIFF
--- a/test/assignment3/assignment-test.sh
+++ b/test/assignment3/assignment-test.sh
@@ -29,7 +29,7 @@ if [[ -z ${DO_VALIDATE} || ${DO_VALIDATE} -eq 1 ]]; then
     ./start-qemu-app.sh ${OUTDIR} &
     echo "Wait for app to finish"
     # See https://stackoverflow.com/a/6456103
-    timeout ${qemu_timeout} grep -q "finder-app execution complete" <(tail -f ${logfile})
+    timeout ${qemu_timeout} grep -q "Completed with success!!" <(tail -f ${logfile})
     rc=$?
     if [ $rc -ne 0 ]; then
         add_validate_error "Running finder application on qemu failed with return code $rc, see ${logfile} for details"


### PR DESCRIPTION
Fixes the bug which was causing test automation to not pick up failure. 

changed the grep string from  **"finder-app execution complete"** to **"Completed with success!!"**