### PR TITLE
Include string.h for strlen.

### DIFF
--- a/test/assignment1/username-from-conf-file.h
+++ b/test/assignment1/username-from-conf-file.h
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <ctype.h>
 
 /**


### PR DESCRIPTION
Fix incompatible implicit declaration of built-in function strlen. See the [issue](https://github.com/cu-ecen-aeld/assignment-autotest/issues/31).

The error message:
```
assignment-autotest/test/assignment1/username-from-conf-file.h:33:36: error: incompatible implicit declaration of built-in function 'strlen' [-Werror]
```