### PR TITLE
Fix a memory leak in the Assignment 1 test code

### DIFF
--- a/test/assignment1/username-from-conf-file.h
+++ b/test/assignment1/username-from-conf-file.h
@@ -10,8 +10,7 @@ static inline char *malloc_username_from_conf_file()
 {
     size_t len = 0;
     // Note: this buffer will be reallocated in getline() as necessary
-    char *buffer = malloc(len + 1);
-    buffer[0] = '\0';
+    char *buffer = NULL;
 
     FILE *fp = fopen("conf/username.txt","r");
     if ( fp != NULL ) {
@@ -38,6 +37,7 @@ static inline char *malloc_username_from_conf_file()
         } else {
             printf("Read %s from conf/username.txt\n", buffer);
         }
+        fclose(fp);
     } else {
         fprintf(stderr, "Could not open conf/username.txt for reading\n");
     }


### PR DESCRIPTION
This commit fixes a memory leak by closing the `conf/username.txt` file after use and letting `getline` allocate its own memory for reading the file.