### PR TITLE
file_write_commands.h: Fix error message

### DIFF
--- a/test/assignment3/file_write_commands.h
+++ b/test/assignment3/file_write_commands.h
@@ -31,7 +31,7 @@ static inline char * malloc_first_line_of_file(const char *filename)
          */
         bytes_read = getline(&buffer, &len, fp);
         if ( bytes_read < 1 ) {
-            printf("Could not read from conf/username.txt\n");
+            printf("Could not read from testfile.txt\n");
         } else {
             // remove delimeter
             if ( buffer[bytes_read-1] == '\r' || buffer[bytes_read-1] == '\n' ) {


### PR DESCRIPTION
The error message does not correspond to the file being read from. This commit fixes it.